### PR TITLE
Fix for recent numpy

### DIFF
--- a/ffx/core.py
+++ b/ffx/core.py
@@ -869,7 +869,7 @@ class FFXModelFactory:
         # alphas = lotsa alphas at beginning, and usual rate for rest
         st, fin = numpy.log10(alpha_max * ss.eps()), numpy.log10(alpha_max)
         alphas1 = numpy.logspace(
-            st, fin, num=ss.numAlphas() * 10)[::-1][:ss.numAlphas() / 4]
+            st, fin, num=ss.numAlphas() * 10)[::-1][:ss.numAlphas() // 4]
         alphas2 = numpy.logspace(st, fin, num=ss.numAlphas())
         alphas = sorted(set(alphas1).union(alphas2), reverse=True)
 


### PR DESCRIPTION
Numpy raises deprication warnings when indexing with a non-integer: this division originally likely did something different in python2.
This changes the code to use integer division.
